### PR TITLE
fix non-filer calculation

### DIFF
--- a/Matching/adj_filst.py
+++ b/Matching/adj_filst.py
@@ -15,7 +15,7 @@ def adjfilst(cps_recs):
                                  (cps_recs['was'] > 0)), 1, 0)
     cps_recs['case2'] = np.where(((cps_recs['filst'] == 0) &
                                   (cps_recs['was'] <= 0)), 1, 0)
-    np.random.seed(142)
+    np.random.seed(409)
     # the first iteration allowed all case1 and case2 records to be selected
     # since
     # 1) if record was case1 then case2 was set to zero and thus was selected

--- a/Matching/cps_rets.py
+++ b/Matching/cps_rets.py
@@ -37,7 +37,7 @@ class Returns(object):
         # Wage thresholds for non-dependent filers
         self.wage1 = 1000
         self.wage2 = 250
-        self.wage2nk = 1000
+        self.wage2nk = 10000
         self.wage3 = 1
         # Dependent exemption
         self.depExempt = 3950
@@ -905,28 +905,35 @@ class Returns(object):
             if unit['depne'] > 0:
                 if unit['was'] >= self.wage2:
                     unit['filst'] = 1
+            else:
                 if unit['was'] >= self.wage2nk:
                     unit['filst'] = 1
+        elif unit['js'] == 3:
+            if unit['was'] >= self.wage3:
+                unit['filst'] = 1
 
         # Gross income test
+        income = (unit['was'] + unit['intst'] + unit['dbe'] + unit['alimony'] +
+                  unit['bil'] + unit['pensions'] + unit['rents'] +
+                  unit['fil'] + unit['ucomp'])
         if unit['js'] == 1:
             amount = self.single - self.depExempt * unit['depne']
             if unit['agede'] != 0:
                 amount = self.single65 - self.depExempt * unit['depne']
-            if unit['income'] >= amount:
+            if income >= amount:
                 unit['filst'] = 1
         if unit['js'] == 2:
             amount = self.joint - self.depExempt * unit['depne']
             if unit['agede'] == 1:
                 amount = self.joint65one - self.depExempt * unit['depne']
                 amount = self.joint65both - self.depExempt * unit['depne']
-            if unit['income'] >= amount:
+            if income >= amount:
                 unit['filst'] = 1
         if unit['js'] == 3:
             amount = self.hoh
             if unit['agede'] != 0:
                 amount = self.hoh65 - self.depExempt * unit['depne']
-            if unit['income'] >= amount:
+            if income >= amount:
                 unit['filst'] = 1
 
         # Dependent filer test
@@ -934,7 +941,7 @@ class Returns(object):
             unit['filst'] = 1
         # Random selection
         if (unit['js'] == 3 and unit['agede'] > 0 and
-                unit['income'] < 6500 and unit['depne'] > 0):
+                income < 6500 and unit['depne'] > 0):
             unit['filst'] = 0
         # Negative incomet test
         if unit['bil'] < 0 or unit['fil'] < 0 or unit['rents'] < 0:

--- a/Matching/runmatch.py
+++ b/Matching/runmatch.py
@@ -71,4 +71,4 @@ def match(mar_cps_path='asec2014_pubuse_tax_fix_5x8.dat',
 
 if __name__ == "__main__":
     cps_matched = match()
-    cps_matched.to_csv('cps-matched-puf.csv')
+    cps_matched.to_csv('cps-matched-puf.csv', index=False)


### PR DESCRIPTION
This PR includes a number of fixes to the calculation of filing status:
1. Correct filing threshold for joint filers with no kids
2. Add `else` statement so the wage of joint filer with no kids is actually compared to its threshold
3. Add `elif` statement so the wages of head of household filers are subjected to the wage test
4. Remove social security from the income calculation for the income test.

Enhancements 1-3 all make moderate changes to the number of non-filers, with 2 and 3 actually slightly decreasing the number.

Number 4 however makes a huge difference as the removal of social security income significantly reduces incomes, causing more tax units to fail the income test.
cc: 
@hdoupe 